### PR TITLE
Add ability to upload parts from CSV and gzip files with the Stream API

### DIFF
--- a/pydomo/DomoAPIClient.py
+++ b/pydomo/DomoAPIClient.py
@@ -1,5 +1,6 @@
 import json
 import requests
+import zlib
 
 from pydomo.Transport import HTTPMethod
 
@@ -72,6 +73,19 @@ class DomoAPIClient(object):
 
     def _upload_csv(self, url, success_code, csv, obj_desc):
         response = self.transport.put_csv(url=url, body=csv)
+        if response.status_code == success_code:
+            if str(response.text) == '':
+                return
+            else:
+                return response.json()
+        else:
+            self.logger.debug("Error uploading " + obj_desc + ": " + self.transport.dump_response(response))
+            raise Exception("Error uploading " + obj_desc + ": "
+                            + response.text)
+
+    def _upload_gzip(self, url, success_code, csv, obj_desc):
+        post_data = zlib.compress(csv.read())
+        response = self.transport.put_gzip(url=url, body=post_data)
         if response.status_code == success_code:
             if str(response.text) == '':
                 return

--- a/pydomo/DomoAPIClient.py
+++ b/pydomo/DomoAPIClient.py
@@ -1,6 +1,5 @@
 import json
 import requests
-import zlib
 
 from pydomo.Transport import HTTPMethod
 
@@ -84,8 +83,7 @@ class DomoAPIClient(object):
                             + response.text)
 
     def _upload_gzip(self, url, success_code, csv, obj_desc):
-        post_data = zlib.compress(csv.read())
-        response = self.transport.put_gzip(url=url, body=post_data)
+        response = self.transport.put_gzip(url=url, body=csv)
         if response.status_code == success_code:
             if str(response.text) == '':
                 return

--- a/pydomo/Transport.py
+++ b/pydomo/Transport.py
@@ -50,6 +50,10 @@ class DomoAPITransport:
         headers = self._headers_send_csv()
         return self.request(url, HTTPMethod.PUT, headers, {}, body)
 
+    def put_gzip(self, url, body):
+        headers = self._headers_send_gzip()
+        return self.request(url, HTTPMethod.PUT, headers, {}, body)
+
     def patch(self, url, body):
         headers = self._headers_send_json()
         return self.request(url, HTTPMethod.PATCH, headers, {},
@@ -104,6 +108,12 @@ class DomoAPITransport:
     def _headers_send_csv(self):
         headers = self._headers_default_receive_json()
         headers['Content-Type'] = 'text/csv'
+        return headers
+
+    def _headers_send_gzip(self):
+        headers = self._headers_default_receive_json()
+        headers['Content-Type'] = 'text/csv'
+        headers['Content-Encoding'] = 'gzip'
         return headers
 
     def _headers_receive_csv(self):

--- a/pydomo/streams/StreamClient.py
+++ b/pydomo/streams/StreamClient.py
@@ -1,3 +1,4 @@
+import os
 import requests
 
 from pydomo.DomoAPIClient import DomoAPIClient
@@ -106,6 +107,12 @@ class StreamClient(DomoAPIClient):
         url = self._base(stream_id) + '/executions/' + str(execution_id) + '/part/' + str(part_num)
         desc = "Data Part on Execution " + str(execution_id) + " on Stream " + str(stream_id)
         return self._upload_csv(url, requests.codes.ok, str.encode(csv), desc)
+
+    def upload_part_from_file(self, stream_id, execution_id, part_num, filepath):
+        with open(os.path.expanduser(filepath), 'rb') as csvfile:
+            url = self._base(stream_id) + '/executions/' + str(execution_id) + '/part/' + str(part_num)
+            desc = "Data Part on Execution " + str(execution_id) + " on Stream " + str(stream_id)
+            return self._upload_csv(url, requests.codes.ok, csvfile, desc)
 
     """
         Commit an Execution (finalize a multi-part upload process)

--- a/pydomo/streams/StreamClient.py
+++ b/pydomo/streams/StreamClient.py
@@ -1,4 +1,5 @@
 import os
+import gzip
 import requests
 
 from pydomo.DomoAPIClient import DomoAPIClient
@@ -113,6 +114,18 @@ class StreamClient(DomoAPIClient):
             url = self._base(stream_id) + '/executions/' + str(execution_id) + '/part/' + str(part_num)
             desc = "Data Part on Execution " + str(execution_id) + " on Stream " + str(stream_id)
             return self._upload_csv(url, requests.codes.ok, csvfile, desc)
+
+    def upload_gzip_part_from_file(self, stream_id, execution_id, part_num, filepath):
+        with open(os.path.expanduser(filepath), 'rb') as csvfile:
+            url = self._base(stream_id) + '/executions/' + str(execution_id) + '/part/' + str(part_num)
+            desc = "Data Part on Execution " + str(execution_id) + " on Stream " + str(stream_id)
+            return self._upload_gzip(url, requests.codes.ok, csvfile, desc)
+
+    def upload_part_from_gzip_file(self, stream_id, execution_id, part_num, filepath):
+        with gzip.open(os.path.expanduser(filepath), 'rb') as gzipfile:
+           url = self._base(stream_id) + '/executions/' + str(execution_id) + '/part/' + str(part_num)
+           desc = "Data Part on Execution " + str(execution_id) + " on Stream " + str(stream_id)
+           return self._upload_gzip(url, requests.codes.ok, gzipfile, desc)
 
     """
         Commit an Execution (finalize a multi-part upload process)

--- a/pydomo/streams/StreamClient.py
+++ b/pydomo/streams/StreamClient.py
@@ -1,5 +1,4 @@
 import os
-import gzip
 import requests
 
 from pydomo.DomoAPIClient import DomoAPIClient
@@ -109,23 +108,59 @@ class StreamClient(DomoAPIClient):
         desc = "Data Part on Execution " + str(execution_id) + " on Stream " + str(stream_id)
         return self._upload_csv(url, requests.codes.ok, str.encode(csv), desc)
 
-    def upload_part_from_file(self, stream_id, execution_id, part_num, filepath):
-        with open(os.path.expanduser(filepath), 'rb') as csvfile:
-            url = self._base(stream_id) + '/executions/' + str(execution_id) + '/part/' + str(part_num)
-            desc = "Data Part on Execution " + str(execution_id) + " on Stream " + str(stream_id)
-            return self._upload_csv(url, requests.codes.ok, csvfile, desc)
+    def upload_csv_part_from_file(self, stream_id, execution_id, part_num, filepath, compression):
 
-    def upload_gzip_part_from_file(self, stream_id, execution_id, part_num, filepath):
-        with open(os.path.expanduser(filepath), 'rb') as csvfile:
-            url = self._base(stream_id) + '/executions/' + str(execution_id) + '/part/' + str(part_num)
-            desc = "Data Part on Execution " + str(execution_id) + " on Stream " + str(stream_id)
-            return self._upload_gzip(url, requests.codes.ok, csvfile, desc)
+        url = self._base(stream_id) + '/executions/' + str(execution_id) + '/part/' + str(part_num)
+        desc = "Data Part on Execution " + str(execution_id) + " on Stream " + str(stream_id)
 
-    def upload_part_from_gzip_file(self, stream_id, execution_id, part_num, filepath):
-        with gzip.open(os.path.expanduser(filepath), 'rb') as gzipfile:
-           url = self._base(stream_id) + '/executions/' + str(execution_id) + '/part/' + str(part_num)
-           desc = "Data Part on Execution " + str(execution_id) + " on Stream " + str(stream_id)
-           return self._upload_gzip(url, requests.codes.ok, gzipfile, desc)
+        if compression == 'gzip':
+
+            import gzip
+
+            if filepath.endswith('.gz'):
+                with gzip.open(os.path.expanduser(filepath), 'rb') as gzipfile:
+                    return self._upload_csv(url, requests.codes.ok, gzipfile, desc)
+
+            else:
+                raise ValueError("Valid gzip extension is '.gz'")
+
+        else:
+            with open(os.path.expanduser(filepath), 'rb') as csvfile:
+                return self._upload_csv(url, requests.codes.ok, csvfile, desc)   
+
+    def upload_gzip_part_from_file(self, stream_id, execution_id, part_num, filepath, stream_file, chunk_size):
+        
+        import gzip
+
+        url = self._base(stream_id) + '/executions/' + str(execution_id) + '/part/' + str(part_num)
+        desc = "Data Part on Execution " + str(execution_id) + " on Stream " + str(stream_id)
+
+        if stream_file:
+            
+            import io
+
+            compressed_body = io.BytesIO()
+            compressed_body.name = url
+            compressor = gzip.open(compressed_body, mode='wb')
+
+            with open(filepath, 'rb') as csvfile:
+                while True:
+                    chunk = csvfile.read(chunk_size)
+                    if not chunk:
+                        break
+                    compressor.write(chunk)
+
+            compressor.flush()
+            compressor.close()
+            compressed_body.seek(0, 0)
+            return self._upload_gzip(url, requests.codes.ok, compressed_body, desc)
+
+        else:
+
+            with open(os.path.expanduser(filepath), 'rb') as csvfile:
+                compressed_body = gzip.compress(csvfile.read())
+                return self._upload_gzip(url, requests.codes.ok, compressed_body, desc)
+
 
     """
         Commit an Execution (finalize a multi-part upload process)


### PR DESCRIPTION
I saw that it might be possible to upload files (including compressed files) to a Stream but the current pydomo SDK seemed to missing functions to do so. The current library supports uploading strings from memory, but that limits the number of rows we can upload at once.

I added a couple of functions to StreamClient.py and made the necessary changes to Transport.py (headers to accept gzip files) and DomoAPIClient.py (upload gzip compressed data) in order to facilitate this. 


Inspiration was from this article:
https://developer.domo.com/docs/stream/upload-in-parallel

