### PR TITLE
Making a PyPI-friendly README

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
     version='0.2.3',
     description=description,
     long_description=long_description,
+    long_description_content_type='text/markdown',
     author='Bobby Swingler',
     author_email='bobby.swingler@domo.com',
     url='https://github.com/domoinc/domo-python-sdk',


### PR DESCRIPTION
Added missing argument to setup.py to make readme show properly in pypi.

Guides:
[Making a PyPI-friendly README](https://packaging.python.org/guides/making-a-pypi-friendly-readme/)
[Stackoverflow Question](https://stackoverflow.com/a/26737258)