### PR TITLE
Adding Pandas to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
     license='MIT',
     packages=find_packages(exclude=['examples']),
     install_requires=[
+        'pandas',
         'requests',
         'requests_toolbelt',
     ],


### PR DESCRIPTION
The current released version of pydomo has a dependency to Pandas, but Pandas was not included in the `setup.py`