### PR TITLE
Fix Issue #64: OverflowError

### DIFF
--- a/pydomo/__init__.py
+++ b/pydomo/__init__.py
@@ -200,6 +200,8 @@ class Domo:
                     pass
                 except TypeError:
                     pass
+                except OverflowError:
+                    pass
 
         return df
 


### PR DESCRIPTION
Issue #64. Catches OverflowError thrown when attempting to convert Dataset fields with large integers represented as strings into dates.