### PR TITLE
Support configuring HTTP / HTTPS proxy

### DIFF
--- a/pydomo/Transport.py
+++ b/pydomo/Transport.py
@@ -15,12 +15,14 @@ class DomoAPITransport:
     serialization and deserialization of objects.
     """
 
-    def __init__(self, client_id, client_secret, api_host, use_https, logger, request_timeout):
+    def __init__(self, client_id, client_secret, api_host, use_https, logger, request_timeout, proxies, verify):
         self.apiHost = self._build_apihost(api_host, use_https)
         self.clientId = client_id
         self.clientSecret = client_secret
         self.logger = logger
         self.request_timeout = request_timeout
+        self.proxies = proxies
+        self.verify = verify
         self._renew_access_token()
 
     @staticmethod
@@ -73,7 +75,10 @@ class DomoAPITransport:
                         'params': params, 'data': body, 'stream': True}
         if self.request_timeout:
             request_args['timeout'] = self.request_timeout
-
+        if self.proxies:
+            request_args['proxies'] = self.proxies
+        if self.verify:
+            request_args['verify'] = self.verify
         # Expiration date should be in UTC
         if datetime.now(timezone.utc).timestamp() > self.token_expiration:
             self.logger.debug("Access token is expired")

--- a/pydomo/Transport.py
+++ b/pydomo/Transport.py
@@ -77,7 +77,7 @@ class DomoAPITransport:
             request_args['timeout'] = self.request_timeout
         if self.proxies:
             request_args['proxies'] = self.proxies
-        if self.verify:
+        if self.verify is not None:
             request_args['verify'] = self.verify
         # Expiration date should be in UTC
         if datetime.now(timezone.utc).timestamp() > self.token_expiration:
@@ -96,6 +96,10 @@ class DomoAPITransport:
         }
         if self.request_timeout:
             request_args['timeout'] = self.request_timeout
+        if self.proxies:
+            request_args['proxies'] = self.proxies
+        if self.verify is not None:
+            request_args['verify'] = self.verify
 
         response = requests.request(**request_args)
         if response.status_code == requests.codes.OK:

--- a/pydomo/__init__.py
+++ b/pydomo/__init__.py
@@ -82,12 +82,14 @@ class Domo:
             self.logger = parent_logger
 
         timeout = kwargs.get('request_timeout', None)
+        proxies = kwargs.get('proxies', None)
+        verify = kwargs.get('verify', True)
 
         if kwargs.get('log_level'):
             self.logger.setLevel(kwargs['log_level'])
         self.logger.debug("\n" + DOMO + "\n")
 
-        self.transport = DomoAPITransport(client_id, client_secret, api_host, kwargs.get('use_https', True), self.logger, request_timeout = timeout)
+        self.transport = DomoAPITransport(client_id, client_secret, api_host, kwargs.get('use_https', True), self.logger, request_timeout = timeout, proxies = proxies, verify = verify)
         self.datasets = DataSetClient(self.transport, self.logger)
         self.groups = GroupClient(self.transport, self.logger)
         self.pages = PageClient(self.transport, self.logger)
@@ -112,7 +114,7 @@ class Domo:
     def ds_delete(self, dataset_id, prompt_before_delete=True):
         """
             Delete a DataSet naming convention equivalent with rdomo
-            
+
             :Parameters:
             - `dataset_id`: id of a dataset (str)
         """


### PR DESCRIPTION
Hi Domo team,

I found current version of the SDK does not have support for configuring HTTP / HTTP proxy, which is necessary for communicating with the API from enterprise networks where outbound traffic to the Internet is ristricted.

I've tried adding new parameters (`proxies` and `verify`) to do this. It would be great if your team could review this PR. Thank you!

```
from pydomo import Domo

proxies = {'https': 'http://someproxy:8080'}
ssl_verify = False

domo = Domo(client_id='*****', client_secret='*****', proxies=proxies, verify=ssl_verify)
```