### PR TITLE
feat(auth): Add scope support

### DIFF
--- a/pydomo/Transport.py
+++ b/pydomo/Transport.py
@@ -15,12 +15,13 @@ class DomoAPITransport:
     serialization and deserialization of objects.
     """
 
-    def __init__(self, client_id, client_secret, api_host, use_https, logger, request_timeout):
+    def __init__(self, client_id, client_secret, api_host, use_https, logger, request_timeout, scope):
         self.apiHost = self._build_apihost(api_host, use_https)
         self.clientId = client_id
         self.clientSecret = client_secret
         self.logger = logger
         self.request_timeout = request_timeout
+        self.scope = scope
         self._renew_access_token()
 
     @staticmethod
@@ -84,10 +85,13 @@ class DomoAPITransport:
 
     def _renew_access_token(self):
         self.logger.debug("Renewing Access Token")
+        # scope == None means use all scopes from client
+        scope = ' '.join(self.scope) if self.scope else None
+
         request_args = {
             'method': HTTPMethod.POST,
             'url': self.apiHost + '/oauth/token',
-            'data': {'grant_type': 'client_credentials'},
+            'data': {'grant_type': 'client_credentials', 'scope': scope},
             'auth': HTTPBasicAuth(self.clientId, self.clientSecret)
         }
         if self.request_timeout:

--- a/pydomo/__init__.py
+++ b/pydomo/__init__.py
@@ -83,12 +83,13 @@ class Domo:
             self.logger = parent_logger
 
         timeout = kwargs.get('request_timeout', None)
+        scope = kwargs.get('scope')
 
         if kwargs.get('log_level'):
             self.logger.setLevel(kwargs['log_level'])
         self.logger.debug("\n" + DOMO + "\n")
 
-        self.transport = DomoAPITransport(client_id, client_secret, api_host, kwargs.get('use_https', True), self.logger, request_timeout = timeout)
+        self.transport = DomoAPITransport(client_id, client_secret, api_host, kwargs.get('use_https', True), self.logger, request_timeout = timeout, scope = scope)
         self.datasets = DataSetClient(self.transport, self.logger)
         self.groups = GroupClient(self.transport, self.logger)
         self.pages = PageClient(self.transport, self.logger)


### PR DESCRIPTION
Adds support for specifying `scope` when creating `Domo` SDK client. `scope` is a list of scope names such as `["data", "user", "account"]`.

This allows limiting the scope of access tokens to a subset of the scopes granted on the API client. Not specifying `scope` maintains the default behavior of access tokens having the same scopes as the API client.

## Example

```python
domo = Domo('client-id','secret',api_host='api.domo.com', scope=['data'])
domo.ds_get('2f09a073-54a4-4269-8c62-b776e67d59f0') # works

domo.users.get(123) # fails, no "user" scope
```