### PR TITLE
Date warning fix and add connection_file as an option when constructing Domo client

### DIFF
--- a/examples/connection.ini
+++ b/examples/connection.ini
@@ -1,0 +1,9 @@
+[client_auth]
+client = replace-me-with-client-id
+secret = replace-me-with-client-secret
+# optional
+api_host = api.domo.com 
+use_https = True
+
+[client_create_auth]
+# sid = "NONE"

--- a/pydomo/__init__.py
+++ b/pydomo/__init__.py
@@ -234,10 +234,11 @@ class Domo:
                         col_name = column["name"]
                         col_type = column["type"]
 
-                        dtype_dict[col_name] = self.utilities.convert_domo_type_to_pandas_type(col_type)
 
                         if self.utilities.is_date_type(col_type):
                             date_columns.append(col_name)
+                        else:
+                            dtype_dict[col_name] = self.utilities.convert_domo_type_to_pandas_type(col_type)
 
                     return read_csv(
                         content, dtype=dtype_dict, parse_dates=date_columns


### PR DESCRIPTION
Users have been getting a warning:
```
An error occurred while converting domo schema to pandas dtypes. 
                Letting pandas attempt to read the data. Error=the dtype datetime64[ns] is not supported for parsing, pass this column using parse_dates instead
/.../lib/python3.12/site-packages/pydomo/utilities/UtilitiesClient.py:66: UserWarning: Could not infer format, so each element will be parsed individually, falling back to `dateutil`. To ensure parsing is consistent and as-expected, please specify a format.
```
when exporting a datasource that contains date columns. It's related to my previous change for version 0.3.0.12 (https://github.com/domoinc/domo-python-sdk/pull/111). The issue is that we were adding the column type for dates to both dtype_dict (which we send to pandas as dtype) and date_columns. The fix was as simple as only setting the column on dtype_dict when it's not a date.

I also added a new parameter `connection_file` to the Domo client init method. This allows providing a file that holds all related connection parameters (client id/secret) rather than having to declare them in each script. This was a problem I ran into while testing for this issue so I assumed it might be an issue other customers have had.